### PR TITLE
Speed up the `navbar-drop` transition

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -362,7 +362,7 @@ body:not(.home) header .logo path {
   list-style: none;
   padding: 5em 0 1em;
   position: absolute;
-  transition: margin-bottom 1s ease-out 0s;
+  transition: margin-bottom .3s ease-out;
   width: 100%;
   z-index: 10;
 }
@@ -1157,7 +1157,6 @@ body:not(.home) .navbar-link:before {
   }
   .navbar-drop.active {
     margin-bottom: -25em;
-    transition: margin-bottom 1s ease-out 0s;
   }
   .navbar-list .navbar-item, .navbar-list .download-item {
     display: none;


### PR DESCRIPTION
This commit decreases the `navbar-drop` transition duration from 1s to
300ms. This makes it much more „snappier“.
