### PR TITLE
Make code blocks scrollable

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -124,6 +124,7 @@ pre > code {
   box-shadow: 0 0 6px 2px rgba(28, 31, 47, 0.1);
   padding: 2em;
   white-space: pre-wrap;
+  overflow-x: auto;
 }
 
 *:not(pre) > code {


### PR DESCRIPTION
This commit makes the code blocks scrollable to fix text-overflow
issues.

**Before:**
![quilljs com-docs-quickstart- iphone 6](https://cloud.githubusercontent.com/assets/2737132/18339916/83533d32-75a2-11e6-9d50-2bd5cb579b2b.png)

**After:**
![quilljs com-docs-quickstart- iphone 6 1](https://cloud.githubusercontent.com/assets/2737132/18339923/8bf35ee0-75a2-11e6-9fab-061d0235fec9.png)
